### PR TITLE
style: allow current color as valid css color

### DIFF
--- a/d2graph/color_helper.go
+++ b/d2graph/color_helper.go
@@ -4,6 +4,7 @@ import "regexp"
 
 // namedColors is a list of valid CSS colors
 var namedColors = []string{
+	"currentcolor",
 	"transparent",
 	"aliceblue",
 	"antiquewhite",


### PR DESCRIPTION
In SVG images `curentColor` is allowed as a way to explicitly inherit the current color. When setting `currentColor` as fill color on a shape together with a styling class, the class will now be used instead of the theme, which was not possible otherwise. This way you can put theme classes on shapes making them respond to dark mode. This is most useful in combination with custom themes.

<!-- Please title the PR with a scope prefix like cli: performance improvements. -->
<!-- Please add screenshots or screencasts for ui/autolayout changes. -->
<!-- Remember to update ci/release/changelogs/next.md, the manpage and cli help documentation. -->
